### PR TITLE
Remove Docker from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,3 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "go.mod:"
-
-  # Maintain dependencies for Docker
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "docker:"


### PR DESCRIPTION
### Description

Dependabot can check for Docker image updates in Dockerfiles only (Docker Compose is not supported).

### Quick checks:

- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-weaviate/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.