### PR TITLE
Fix GoReleaser config, remove Docker from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,3 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "go.mod:"
-
-  # Maintain dependencies for Docker
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: "docker:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

This PR:

1. Fixes the GoReleaser config
2. Removes Docker from dependabot config (dependabot doesn't support scanning Docker Compose files)

### Quick checks:

- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-weaviate/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.