### PR TITLE
GoReleaser: Skip 32-bit builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 
 ### vim ###
 *.swp
+
+### GoReleaser ###
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ builds:
       - darwin
       - linux
       - windows
+    ignore:
+      - goarch: "386"
     env:
       - CGO_ENABLED=0
     ldflags:


### PR DESCRIPTION
### Description

Fixes #48.

### Quick checks:

- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-weaviate/pulls) for the same update/change.
- [ ] I have written unit tests.
  - Tested locally with `goreleaser release --clean --snapshot`
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.